### PR TITLE
changed script to return NXDOMAIN, not localhost; updated domainlist

### DIFF
--- a/adblocklist
+++ b/adblocklist
@@ -47,6 +47,7 @@ accounts.pkr.com
 acsseo.com
 actionsplash.com
 actualdeals.com
+ad-center.com
 ad-flow.com
 ad-images.suntimes.com
 ad-pay.de
@@ -246,7 +247,6 @@ adimg.uimserv.net
 adimg1.chosun.com
 adimgs.sapo.pt
 adimpact.com
-adincl.gopher.com
 adinjector.net
 adinterax.com
 adisfy.com
@@ -266,6 +266,7 @@ adlink.de
 adlog.com.com
 adloox.com
 adlooxtracking.com
+adlure.net
 adm.ad.asap-asp.net
 admagnet.net
 admailtiser.com
@@ -528,8 +529,6 @@ ads.linuxsecurity.com
 ads.livenation.com
 ads.localnow.com
 ads.lvz-online.de
-ads.mambocommunities.com
-ads.mariuana.it
 ads.massinfra.nl
 ads.mcafee.com
 ads.mediaodyssey.com
@@ -663,6 +662,7 @@ ads.v3.com
 ads.verticalresponse.com
 ads.vgchartz.com
 ads.videosz.com
+ads.viewx.co.uk
 ads.virtual-nights.com
 ads.virtualcountries.com
 ads.vnumedia.com
@@ -810,13 +810,11 @@ adserver2.popdata.de
 adserverplus.com
 adserversolutions.com
 adserveuk.com
-adserving.eleven-agency.com
 adservinginternational.com
 adsfac.eu
 adsfac.net
 adsfac.us
 adshost1.com
-adshuffle.com
 adside.com
 adskape.ru
 adsklick.de
@@ -835,6 +833,7 @@ adsremote.scrippsnetworks.com
 adsrevenue.net
 adsrv.deviantart.com
 adsrv.iol.co.za
+adsrvr.org
 adsstat.com
 adstat.4u.pl
 adstest.weather.com
@@ -855,7 +854,6 @@ adtrade.net
 adtrading.de
 adtrak.net
 adtriplex.com
-adult-adv.com
 adultadvertising.com
 adv-adserver.com
 adv-banner.libero.it
@@ -904,7 +902,6 @@ adworx.at
 adworx.be
 adworx.nl
 adx.allstar.cz
-adx.arip.co.th
 adx.atnext.com
 adx.gainesvillesun.com
 adxpansion.com
@@ -923,7 +920,6 @@ affiliate.7host.com
 affiliate.doubleyourdating.com
 affiliate.dtiserv.com
 affiliate.gamestop.com
-affiliate.kitapyurdu.com
 affiliate.mercola.com
 affiliate.mogs.com
 affiliate.offgamers.com
@@ -961,7 +957,6 @@ allosponsor.com
 amazingcounters.com
 amung.us
 an.tacoda.net
-anahtars.com
 analytics.live.com
 analytics.yahoo.com
 anm.intelli-direct.com
@@ -983,7 +978,6 @@ assoc-amazon.com
 at-adserver.alltop.com
 atdmt.com
 athena-ads.wikia.com
-atopsites.com
 atwola.com
 auctionads.com
 auctionads.net
@@ -1148,7 +1142,6 @@ braincash.com
 brandreachsys.com
 bravenet.com
 bridgetrack.com
-british-banners.com
 bs.yandex.ru
 budsinc.com
 bullseye.backbeatmedia.com
@@ -1195,7 +1188,6 @@ checkm8.com
 checkstat.nl
 chestionar.ro
 chitika.net
-ciaoclick.com
 cibleclick.com
 cityads.telus.net
 cj.com
@@ -1287,7 +1279,6 @@ counter.nowlinux.com
 counter.rambler.ru
 counter.search.bg
 counter.sparklit.com
-counter.times.lv
 counter.yadro.ru
 counters.honesty.com
 counting.kmindex.ru
@@ -1334,7 +1325,6 @@ depilflash.tv
 di1.shopping.com
 dialerporn.com
 didtheyreadit.com
-digits.com
 direct-xxx-access.com
 directaclick.com
 directivepub.com
@@ -1458,7 +1448,6 @@ freebanner.com
 freelogs.com
 freeonlineusers.com
 freepay.com
-freestat.pl
 freestats.com
 freestats.tv
 freewebcounter.com
@@ -1595,7 +1584,6 @@ infinite-ads.com
 infinityads.com
 infolinks.com
 information.com
-infra-ad.com
 initgroup.com
 inringtone.com
 insightexpress.com
@@ -1786,7 +1774,6 @@ nedstatbasic.net
 nedstatpro.net
 nend.net
 neocounter.neoworx-blog-tools.net
-neocounter.net
 neoffic.com
 net-filter.com
 netaffiliation.com
@@ -1879,7 +1866,6 @@ pagerank4you.com
 pageranktop.com
 partage-facile.com
 partner-ads.com
-partner.gonamic.de
 partner.pelikan.cz
 partner.topcities.com
 partnerad.l.google.com
@@ -1955,7 +1941,6 @@ promobenef.com
 promos.fling.com
 promote.pair.com
 promotion-campaigns.com
-promozia.de
 pronetadvertising.com
 propellerads.com
 proranktracker.com
@@ -2085,7 +2070,6 @@ servethis.com
 service1.adten.de
 services.hearstmags.com
 serving-sys.com
-sexaddpro.de
 sexcounter.com
 sexinyourcity.com
 sexlist.com
@@ -2429,8 +2413,6 @@ yieldmanager.com
 yieldmanager.net
 yoc.mobi
 yoggrt.com
-yourtracking.net
-z.times.lv
 z5x.net
 zangocash.com
 zanox-affiliate.de

--- a/generate_list.py
+++ b/generate_list.py
@@ -18,8 +18,7 @@ adservers = open('adblocklist')
 # possible zone types are:
 #   deny refuse static transparent redirect nodefault
 
-sZonetype = 'redirect'
-sDestination = "A 127.0.0.1"
+sZonetype = 'static'
 
 ##
 # generate unbound config entry for each server
@@ -27,5 +26,5 @@ sDestination = "A 127.0.0.1"
 for sServer in adservers:
   sServer = sServer.replace('\n', '')
 
+# generate a empty static zone, so unbound answers with NXDOMAIN
   print('local-zone: "' + sServer + '" ' + sZonetype)
-  print('local-data: "' + sServer + ' ' + sDestination + '"')


### PR DESCRIPTION
It's better to let Unbound return NXDOMAIN, because client thinks there is no destination for it available, otherwise it try's to connect to localhost, what we don't want.

Aand updated domain list to the latest updated of May 2.